### PR TITLE
Add auto-relax after add

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ See it at work in [the test workflow for this project](https://github.com/madkin
 
 > Can this plugin change the behavior of `poetry add` to relax constraints?
 
-Not at this time. The Poetry project states that plugins must not alter the behavior of core Poetry commands. If this behavior would be useful for you, please chime in [on the tracking issue](https://github.com/madkinsz/poetry-relax/issues/5).
+Yes. You can update your `pyproject.toml` with the following configuration to automatically run `poetry relax`
+after `poetry add`:
+
+```toml
+[tool.poetry-relax]
+relax_on_add = true
+```
 
 > Does this plugin remove upper constraints I've added?
 

--- a/src/poetry_relax/__init__.py
+++ b/src/poetry_relax/__init__.py
@@ -1,4 +1,8 @@
+from cleo.events.console_command_event import ConsoleCommandEvent
+from cleo.events.console_events import COMMAND, TERMINATE
+from cleo.events.event_dispatcher import EventDispatcher
 from poetry.console.application import Application
+from poetry.console.commands.add import AddCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
 
 from poetry_relax.command import RelaxCommand
@@ -13,3 +17,41 @@ def _command_factory() -> RelaxCommand:
 class RelaxPlugin(ApplicationPlugin):
     def activate(self, application: Application):
         application.command_loader.register_factory("relax", _command_factory)
+        application.event_dispatcher.add_listener(TERMINATE, self._auto_relax)
+
+    def _auto_relax(
+        self, event: ConsoleCommandEvent, event_name: str, dispatcher: EventDispatcher
+    ) -> None:
+        # Do not run on failed commands
+        if event.exit_code:
+            return event.exit_code
+
+        # Only run on `poetry add`
+        if not isinstance(event.command, AddCommand):
+            return event.exit_code
+
+        # Only run on opt-in
+        if (
+            not event.command.poetry.pyproject.data.get("tool", {})
+            .get("poetry-relax", {})
+            .get("relax_on_add", False)
+        ):
+            return
+
+        # Parse options from `poetry add ...` to send to `poetry relax`
+        args = []
+        group = "dev" if event.command.option("dev") else event.command.option("group")
+        if group:
+            args.extend(["--only", group])
+        if event.command.option("dry-run"):
+            args.append("--dry-run")
+        if event.command.option("quiet"):
+            args.append("--quiet")
+        if event.command.option("verbose"):
+            args.append("--verbose")
+        if event.command.option("lock"):
+            args.append("--lock")
+
+        # Write a new line for readability
+        event.command.io.write_line("")
+        return event.command.call("relax", " ".join(args))


### PR DESCRIPTION
Runs `poetry relax` after `poetry add` succeeds. Parses options from `add` and sends them to `relax` to try to keep the same scope as an `add` command. For example, `--dry-run` is passed through to prevent relaxing when something wasn't actually added and `--group` is passed through to prevent relaxing outside of the group an item is added to.

Requires opt-in with configuration

```toml
[tool.poetry-relax]
relax_on_add = true
```

Closes #5 

Needs tests