### PR TITLE
Fix bug where relax would fail when git dependencies are present

### DIFF
--- a/src/poetry_relax/_core.py
+++ b/src/poetry_relax/_core.py
@@ -262,6 +262,10 @@ def drop_caret_bound_from_dependency(dependency: "Dependency") -> "Dependency":
     # Copy the existing dependency to retain as much information as possible
     new_dependency = copy(dependency)
 
+    # If the constraint is empty, assignment will fail
+    if not new_version:
+        return dependency
+
     # Update the constraint to the new version
     # The property setter parses this into a proper constraint type
     new_dependency.constraint = new_version  # type: ignore

--- a/src/poetry_relax/_core.py
+++ b/src/poetry_relax/_core.py
@@ -255,6 +255,10 @@ def drop_caret_bound_from_dependency(dependency: "Dependency") -> "Dependency":
     If the dependency does not use a caret constraint to specify its upper bound,
     it will not be changed but a new copy will be returned.
     """
+    # If the constraint is empty, there is nothing to do
+    if not dependency.pretty_constraint:
+        return dependency
+
     new_version = mutate_constraint(
         dependency.pretty_constraint, drop_upper_bound_from_caret_constraint
     )
@@ -264,7 +268,9 @@ def drop_caret_bound_from_dependency(dependency: "Dependency") -> "Dependency":
 
     # If the constraint is empty, assignment will fail
     if not new_version:
-        return dependency
+        raise ValueError(
+            f"Updating constraint for {dependency} resulted in an empty version"
+        )
 
     # Update the constraint to the new version
     # The property setter parses this into a proper constraint type

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -335,6 +335,22 @@ def test_dependency_with_additional_options(relax_command: PoetryCommandTester):
     assert relax_command.status_code == 0
 
 
+def test_dependency_with_git_url(relax_command: PoetryCommandTester):
+    with update_pyproject() as pyproject:
+        pyproject["tool"]["poetry"]["dependencies"]["test"] = {
+            "git": "https://github.com/zanieb/test.git"
+        }
+
+    with assert_pyproject_matches() as expected_config:
+        relax_command.execute()
+
+        expected_config["tool"]["poetry"]["dependencies"]["test"] = {
+            "git": "https://github.com/zanieb/test.git"
+        }
+
+    assert relax_command.status_code == 0
+
+
 def test_dependency_with_multiple_conditional_versions(
     relax_command: PoetryCommandTester,
 ):


### PR DESCRIPTION
Closes #89 

- Add failing test case for #89
- Avoid updating the constraint when it is empty
- Improve error message when constraint updates fail
